### PR TITLE
Mystical Agriculture Compatibility with Farmer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ repositories {
 	}
 	maven {
 		name = "Blakebr0"
-		url = "https://maven.blakesmods.com/#/releases"
+		url = "https://maven.blakesmods.com/releases"
 		content {
 			// Cucumber
 			includeGroup "com.blakebr0.cucumber"
@@ -124,11 +124,11 @@ dependencies {
 	}
 
 	if (project.runtime_include_mystical_agriculture.toBoolean()) {
-		localImplementation "com.blakebr0.mysticalagriculture:MysticalAgriculture:${mystical_agriculture_version}"
 		localImplementation "com.blakebr0.cucumber:Cucumber:${cucumber_version}"
+		localImplementation "com.blakebr0.mysticalagriculture:MysticalAgriculture:${mystical_agriculture_version}"
 	} else {
-		compileOnly "com.blakebr0.mysticalagriculture:MysticalAgriculture:${mystical_agriculture_version}"
 		compileOnly "com.blakebr0.cucumber:Cucumber:${cucumber_version}"
+		compileOnly "com.blakebr0.mysticalagriculture:MysticalAgriculture:${mystical_agriculture_version}"
 	}
 }
 
@@ -367,8 +367,7 @@ tasks.withType(ProcessResources).configureEach {
 			emi_version_range                     : emi_version_range,
 			accessories_version_range             : accessories_version_range,
 			curios_version_range                  : curios_version_range,
-			mystical_agriculture_version_range	  : mystical_agriculture_version_range,
-			cucumber_version_range				  : cucumber_version_range
+			mystical_agriculture_version_range    : mystical_agriculture_version_range
 	]
 	inputs.properties replaceProperties
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,16 @@ repositories {
 			includeGroup "top.theillusivec4.curios"
 		}
 	}
+	maven {
+		name = "Blakebr0"
+		url = "https://maven.blakesmods.com/#/releases"
+		content {
+			// Cucumber
+			includeGroup "com.blakebr0.cucumber"
+			// Mystical Agriculture
+			includeGroup "com.blakebr0.mysticalagriculture"
+		}
+	}
 }
 
 dependencies {
@@ -111,6 +121,14 @@ dependencies {
 		localImplementation "top.theillusivec4.curios:curios-neoforge:${curios_version}"
 	} else {
 		compileOnly "top.theillusivec4.curios:curios-neoforge:${curios_version}"
+	}
+
+	if (project.runtime_include_mystical_agriculture.toBoolean()) {
+		localImplementation "com.blakebr0.mysticalagriculture:MysticalAgriculture:${mystical_agriculture_version}"
+		localImplementation "com.blakebr0.cucumber:Cucumber:${cucumber_version}"
+	} else {
+		compileOnly "com.blakebr0.mysticalagriculture:MysticalAgriculture:${mystical_agriculture_version}"
+		compileOnly "com.blakebr0.cucumber:Cucumber:${cucumber_version}"
 	}
 }
 
@@ -348,7 +366,9 @@ tasks.withType(ProcessResources).configureEach {
 			mi_tweaks_version_range               : mi_tweaks_version_range,
 			emi_version_range                     : emi_version_range,
 			accessories_version_range             : accessories_version_range,
-			curios_version_range                  : curios_version_range
+			curios_version_range                  : curios_version_range,
+			mystical_agriculture_version_range	  : mystical_agriculture_version_range,
+			cucumber_version_range				  : cucumber_version_range
 	]
 	inputs.properties replaceProperties
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ runtime_include_emi=true
 runtime_include_mi_tweaks=true
 runtime_include_accessories=false
 runtime_include_curios=false
+runtime_include_mystical_agriculture=false
 
 # Gradle Configuration
 artifact_name=extended-industrialization
@@ -48,3 +49,7 @@ accessories_version=1.0.0-beta.34+1.21
 accessories_version_range=[1.0.0-beta.34-, 1.1.0-)
 curios_version=9.0.10+1.21
 curios_version_range=[9,)
+cucumber_version=1.21.1-8.0.8
+cucumber_version_range=[1.21.1-8.0.0, 1.21.1-9-]
+mystical_agriculture_version=1.21.1-8.0.9
+mystical_agriculture_version_range=[1.21.1-8.0.0, 1.21.1-9-]

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,6 +50,5 @@ accessories_version_range=[1.0.0-beta.34-, 1.1.0-)
 curios_version=9.0.10+1.21
 curios_version_range=[9,)
 cucumber_version=1.21.1-8.0.8
-cucumber_version_range=[1.21.1-8.0.0, 1.21.1-9-]
 mystical_agriculture_version=1.21.1-8.0.9
-mystical_agriculture_version_range=[1.21.1-8.0.0, 1.21.1-9-]
+mystical_agriculture_version_range=[8.0.0,)

--- a/src/main/java/net/swedz/extended_industrialization/machines/component/farmer/FarmerComponent.java
+++ b/src/main/java/net/swedz/extended_industrialization/machines/component/farmer/FarmerComponent.java
@@ -25,6 +25,7 @@ import net.swedz.extended_industrialization.machines.component.farmer.harvesting
 import net.swedz.extended_industrialization.machines.component.farmer.harvesting.harvestable.NetherWartHarvestable;
 import net.swedz.extended_industrialization.machines.component.farmer.harvesting.harvestable.SimpleTallCropHarvestable;
 import net.swedz.extended_industrialization.machines.component.farmer.harvesting.harvestable.TreeHarvestable;
+import net.swedz.extended_industrialization.machines.component.farmer.harvesting.harvestable.MysticalAgricultureHarvestable;
 import net.swedz.extended_industrialization.machines.component.farmer.planting.FarmerPlantable;
 import net.swedz.extended_industrialization.machines.component.farmer.planting.PlantableBehaviorHolder;
 import net.swedz.extended_industrialization.machines.component.farmer.planting.PlantingContext;
@@ -34,6 +35,7 @@ import net.swedz.extended_industrialization.machines.component.farmer.task.Farme
 import net.swedz.extended_industrialization.machines.component.farmer.task.FarmerTask;
 import net.swedz.extended_industrialization.machines.component.farmer.task.FarmerTaskType;
 import net.swedz.tesseract.neoforge.behavior.BehaviorRegistry;
+import net.swedz.tesseract.neoforge.compat.ModLoadedHelper;
 import net.swedz.tesseract.neoforge.compat.mi.helper.MachineInventoryHelper;
 import net.swedz.tesseract.neoforge.event.FarmlandLoseMoistureEvent;
 
@@ -61,7 +63,11 @@ public final class FarmerComponent implements IComponent
 	{
 		registerPlantable(StandardFarmerPlantable::new);
 		registerPlantable(SpecialFarmerPlantable::new);
-		
+
+		if (ModLoadedHelper.isLoaded("mysticalagriculture")) {
+			registerHarvestable(MysticalAgricultureHarvestable::new);
+		}
+
 		registerHarvestable(CropBlockHarvestable::new);
 		registerHarvestable(NetherWartHarvestable::new);
 		registerHarvestable(SimpleTallCropHarvestable::new);
@@ -81,11 +87,11 @@ public final class FarmerComponent implements IComponent
 	
 	private final List<FarmerListener<? extends Event>> listeners = Lists.newArrayList();
 	
-	private Level   level;
-	private boolean listenersRegistered = false;
-	
 	public PlantingMode plantingMode;
 	public boolean      tilling;
+	
+	private Level        level;
+	private ShapeMatcher shapeMatcher;
 	
 	private int processTick;
 	
@@ -203,12 +209,12 @@ public final class FarmerComponent implements IComponent
 	
 	public void registerListeners(Level level, ShapeMatcher shapeMatcher)
 	{
-		if(listenersRegistered)
+		if(this.shapeMatcher != null)
 		{
 			throw new IllegalStateException("There are already listeners registered on this FarmerComponent");
 		}
-		listenersRegistered = true;
 		this.level = level;
+		this.shapeMatcher = shapeMatcher;
 		for(FarmerListener listener : listeners)
 		{
 			EILocalizedListeners.INSTANCE.register(level, shapeMatcher.getSpannedChunks(), listener.eventClass(), listener.listener());
@@ -221,7 +227,7 @@ public final class FarmerComponent implements IComponent
 		{
 			EILocalizedListeners.INSTANCE.unregister(level, shapeMatcher.getSpannedChunks(), listener.eventClass(), listener.listener());
 		}
-		this.listenersRegistered = false;
+		this.shapeMatcher = null;
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/extended_industrialization/machines/component/farmer/FarmerComponent.java
+++ b/src/main/java/net/swedz/extended_industrialization/machines/component/farmer/FarmerComponent.java
@@ -87,12 +87,12 @@ public final class FarmerComponent implements IComponent
 	
 	private final List<FarmerListener<? extends Event>> listeners = Lists.newArrayList();
 	
+	private Level   level;
+	private boolean listenersRegistered = false;
+
 	public PlantingMode plantingMode;
 	public boolean      tilling;
-	
-	private Level        level;
-	private ShapeMatcher shapeMatcher;
-	
+
 	private int processTick;
 	
 	public FarmerComponent(MultiblockInventoryComponent inventory, IsActiveComponent isActive, PlantingMode defaultPlantingMode, FarmerProcessRates processRates)
@@ -209,12 +209,12 @@ public final class FarmerComponent implements IComponent
 	
 	public void registerListeners(Level level, ShapeMatcher shapeMatcher)
 	{
-		if(this.shapeMatcher != null)
+		if(listenersRegistered)
 		{
 			throw new IllegalStateException("There are already listeners registered on this FarmerComponent");
 		}
+		listenersRegistered = true;
 		this.level = level;
-		this.shapeMatcher = shapeMatcher;
 		for(FarmerListener listener : listeners)
 		{
 			EILocalizedListeners.INSTANCE.register(level, shapeMatcher.getSpannedChunks(), listener.eventClass(), listener.listener());
@@ -227,7 +227,7 @@ public final class FarmerComponent implements IComponent
 		{
 			EILocalizedListeners.INSTANCE.unregister(level, shapeMatcher.getSpannedChunks(), listener.eventClass(), listener.listener());
 		}
-		this.shapeMatcher = null;
+		this.listenersRegistered = false;
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/extended_industrialization/machines/component/farmer/FarmerComponent.java
+++ b/src/main/java/net/swedz/extended_industrialization/machines/component/farmer/FarmerComponent.java
@@ -22,10 +22,10 @@ import net.swedz.extended_industrialization.machines.component.farmer.harvesting
 import net.swedz.extended_industrialization.machines.component.farmer.harvesting.HarvestableBehaviorHolder;
 import net.swedz.extended_industrialization.machines.component.farmer.harvesting.HarvestingContext;
 import net.swedz.extended_industrialization.machines.component.farmer.harvesting.harvestable.CropBlockHarvestable;
+import net.swedz.extended_industrialization.machines.component.farmer.harvesting.harvestable.MysticalAgricultureHarvestable;
 import net.swedz.extended_industrialization.machines.component.farmer.harvesting.harvestable.NetherWartHarvestable;
 import net.swedz.extended_industrialization.machines.component.farmer.harvesting.harvestable.SimpleTallCropHarvestable;
 import net.swedz.extended_industrialization.machines.component.farmer.harvesting.harvestable.TreeHarvestable;
-import net.swedz.extended_industrialization.machines.component.farmer.harvesting.harvestable.MysticalAgricultureHarvestable;
 import net.swedz.extended_industrialization.machines.component.farmer.planting.FarmerPlantable;
 import net.swedz.extended_industrialization.machines.component.farmer.planting.PlantableBehaviorHolder;
 import net.swedz.extended_industrialization.machines.component.farmer.planting.PlantingContext;
@@ -63,11 +63,12 @@ public final class FarmerComponent implements IComponent
 	{
 		registerPlantable(StandardFarmerPlantable::new);
 		registerPlantable(SpecialFarmerPlantable::new);
-
-		if (ModLoadedHelper.isLoaded("mysticalagriculture")) {
+		
+		if(ModLoadedHelper.isLoaded("mysticalagriculture"))
+		{
 			registerHarvestable(MysticalAgricultureHarvestable::new);
 		}
-
+		
 		registerHarvestable(CropBlockHarvestable::new);
 		registerHarvestable(NetherWartHarvestable::new);
 		registerHarvestable(SimpleTallCropHarvestable::new);
@@ -89,10 +90,10 @@ public final class FarmerComponent implements IComponent
 	
 	private Level   level;
 	private boolean listenersRegistered = false;
-
+	
 	public PlantingMode plantingMode;
 	public boolean      tilling;
-
+	
 	private int processTick;
 	
 	public FarmerComponent(MultiblockInventoryComponent inventory, IsActiveComponent isActive, PlantingMode defaultPlantingMode, FarmerProcessRates processRates)

--- a/src/main/java/net/swedz/extended_industrialization/machines/component/farmer/harvesting/harvestable/MysticalAgricultureHarvestable.java
+++ b/src/main/java/net/swedz/extended_industrialization/machines/component/farmer/harvesting/harvestable/MysticalAgricultureHarvestable.java
@@ -1,0 +1,44 @@
+package net.swedz.extended_industrialization.machines.component.farmer.harvesting.harvestable;
+
+import com.google.common.collect.Lists;
+import net.minecraft.core.BlockPos;
+import com.blakebr0.mysticalagriculture.block.MysticalCropBlock;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.storage.loot.LootParams;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.phys.Vec3;
+import net.swedz.extended_industrialization.machines.component.farmer.harvesting.HarvestableBehavior;
+import net.swedz.extended_industrialization.machines.component.farmer.harvesting.HarvestingContext;
+import java.util.List;
+
+public final class MysticalAgricultureHarvestable implements HarvestableBehavior {
+    @Override
+    public boolean matches(HarvestingContext context) {
+        return context.state().getBlock() instanceof MysticalCropBlock;
+    }
+
+    @Override
+    public boolean isFullyGrown(HarvestingContext context) {
+        MysticalCropBlock mysticalCropBlock = (MysticalCropBlock) context.state().getBlock();
+        return mysticalCropBlock.isMaxAge(context.state());
+    }
+
+    @Override
+    public List<BlockPos> getBlocks(HarvestingContext context) {
+        return Lists.newArrayList(context.pos());
+    }
+
+    @Override
+    public List<ItemStack> getDrops(HarvestingContext context) {
+        MysticalCropBlock cropBlock = (MysticalCropBlock) context.state().getBlock();
+        // Handle Mystical Agriculture crops
+        // Build LootParams for Mystical Agriculture
+        LootParams.Builder builder = new LootParams.Builder((ServerLevel) context.level())
+                .withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(context.pos()))
+                .withParameter(LootContextParams.TOOL, ItemStack.EMPTY); // Include the harvesting tool if applicable
+
+        // Use Mystical Agriculture's custom drop logic
+        return cropBlock.getDrops(context.state(), builder);
+    }
+}

--- a/src/main/java/net/swedz/extended_industrialization/machines/component/farmer/harvesting/harvestable/MysticalAgricultureHarvestable.java
+++ b/src/main/java/net/swedz/extended_industrialization/machines/component/farmer/harvesting/harvestable/MysticalAgricultureHarvestable.java
@@ -1,8 +1,8 @@
 package net.swedz.extended_industrialization.machines.component.farmer.harvesting.harvestable;
 
+import com.blakebr0.mysticalagriculture.block.MysticalCropBlock;
 import com.google.common.collect.Lists;
 import net.minecraft.core.BlockPos;
-import com.blakebr0.mysticalagriculture.block.MysticalCropBlock;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.storage.loot.LootParams;
@@ -10,35 +10,37 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.Vec3;
 import net.swedz.extended_industrialization.machines.component.farmer.harvesting.HarvestableBehavior;
 import net.swedz.extended_industrialization.machines.component.farmer.harvesting.HarvestingContext;
+
 import java.util.List;
 
-public final class MysticalAgricultureHarvestable implements HarvestableBehavior {
-    @Override
-    public boolean matches(HarvestingContext context) {
-        return context.state().getBlock() instanceof MysticalCropBlock;
-    }
-
-    @Override
-    public boolean isFullyGrown(HarvestingContext context) {
-        MysticalCropBlock mysticalCropBlock = (MysticalCropBlock) context.state().getBlock();
-        return mysticalCropBlock.isMaxAge(context.state());
-    }
-
-    @Override
-    public List<BlockPos> getBlocks(HarvestingContext context) {
-        return Lists.newArrayList(context.pos());
-    }
-
-    @Override
-    public List<ItemStack> getDrops(HarvestingContext context) {
-        MysticalCropBlock cropBlock = (MysticalCropBlock) context.state().getBlock();
-        // Handle Mystical Agriculture crops
-        // Build LootParams for Mystical Agriculture
-        LootParams.Builder builder = new LootParams.Builder((ServerLevel) context.level())
-                .withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(context.pos()))
-                .withParameter(LootContextParams.TOOL, ItemStack.EMPTY); // Include the harvesting tool if applicable
-
-        // Use Mystical Agriculture's custom drop logic
-        return cropBlock.getDrops(context.state(), builder);
-    }
+public final class MysticalAgricultureHarvestable implements HarvestableBehavior
+{
+	@Override
+	public boolean matches(HarvestingContext context)
+	{
+		return context.state().getBlock() instanceof MysticalCropBlock;
+	}
+	
+	@Override
+	public boolean isFullyGrown(HarvestingContext context)
+	{
+		MysticalCropBlock mysticalCropBlock = (MysticalCropBlock) context.state().getBlock();
+		return mysticalCropBlock.isMaxAge(context.state());
+	}
+	
+	@Override
+	public List<BlockPos> getBlocks(HarvestingContext context)
+	{
+		return Lists.newArrayList(context.pos());
+	}
+	
+	@Override
+	public List<ItemStack> getDrops(HarvestingContext context)
+	{
+		MysticalCropBlock cropBlock = (MysticalCropBlock) context.state().getBlock();
+		LootParams.Builder builder = new LootParams.Builder((ServerLevel) context.level())
+				.withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(context.pos()))
+				.withParameter(LootContextParams.TOOL, ItemStack.EMPTY);
+		return cropBlock.getDrops(context.state(), builder);
+	}
 }

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -66,3 +66,10 @@ type = "optional"
 versionRange = "${curios_version_range}"
 ordering = "AFTER"
 side = "BOTH"
+
+[[dependencies.${ mod_id }]]
+modId = "mysticalagriculture"
+type = "optional"
+versionRange = "${mystical_agriculture_version_range}"
+ordering = "AFTER"
+side = "BOTH"


### PR DESCRIPTION
Introduced compatibility between Mystical Agriculture crops and the Farmer.

- Added Mystical Agriculture to project dependencies to build.gradle and gradle.properties
- Added new MysticalAgricultureHarvestable class to the harvesting handlers
- Added logic to FarmerComponent.java to check if Mystical Agriculture is loaded and to register the new harvestable class if it is. This allows compatibility even if Mystical Agriculture is not installed.

Have tested against all seed and crop types in Mystical Agriculture. It is using Mystical Agricultures getDrop logic so honours bonuses from essence farmland and crux blocks in the Mystical Agriculture mod.