### PR TITLE
Fix machine block properties for Lethal Tesla Coil and Tesla Particle Generator

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ mod_discord_icon=https://cdn.discordapp.com/emojis/1264330258505531473.webp
 # NeoForge Environment
 minecraft_version=1.21.1
 minecraft_version_range=1.21.1
-neoforge_version=21.1.113
+neoforge_version=21.1.209
 parchment_mappings_minecraft_version=1.21
 parchment_mappings_version=2024.07.28
 loader_version_range=[4,)
@@ -38,14 +38,14 @@ mod_description=An addon mod that extends the content in Modern Industrializatio
 mod_github=https://github.com/Swedz/Extended-Industrialization
 
 # Dependencies
-modern_industrialization_version=2.3.11
-modern_industrialization_version_range=[2.3.11-, 2.4-)
+modern_industrialization_version=2.3.13
+modern_industrialization_version_range=[2.3.13-, 2.4-)
 grandpower_version=3.0.0
 cloth_config_version=15.0.127
 emi_version=1.1.10+1.21
 emi_version_range=[1.1.10, 1.2-)
-tesseract_version=1.9.0-1.21.1
-tesseract_version_range=[1.9.0-, 1.10-)
+tesseract_version=1.9.2-1.21.1
+tesseract_version_range=[1.9.2-, 1.10-)
 mi_tweaks_version=1.8.2-1.21.1
 mixinextras_version=0.3.5
 accessories_version=1.0.0-beta.34+1.21

--- a/src/main/java/net/swedz/extended_industrialization/EIClient.java
+++ b/src/main/java/net/swedz/extended_industrialization/EIClient.java
@@ -57,7 +57,7 @@ import net.swedz.tesseract.neoforge.item.DynamicDyedItem;
 import net.swedz.tesseract.neoforge.registry.holder.ItemHolder;
 
 @Mod(value = EI.ID, dist = Dist.CLIENT)
-@EventBusSubscriber(value = Dist.CLIENT, modid = EI.ID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = EI.ID, value = Dist.CLIENT)
 public final class EIClient
 {
 	public EIClient(IEventBus bus, ModContainer container)

--- a/src/main/java/net/swedz/extended_industrialization/EIClientModels.java
+++ b/src/main/java/net/swedz/extended_industrialization/EIClientModels.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-@EventBusSubscriber(modid = EI.ID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = EI.ID, value = Dist.CLIENT)
 public final class EIClientModels
 {
 	private static NanoArmorModel                NANO_ARMOR_INNER;

--- a/src/main/java/net/swedz/extended_industrialization/EIClientRenderTypes.java
+++ b/src/main/java/net/swedz/extended_industrialization/EIClientRenderTypes.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 import static net.minecraft.client.renderer.RenderStateShard.*;
 import static net.swedz.extended_industrialization.EIClientShaders.*;
 
-@EventBusSubscriber(modid = EI.ID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+@EventBusSubscriber(modid = EI.ID, value = Dist.CLIENT)
 public final class EIClientRenderTypes
 {
 	public static final BiFunction<ResourceLocation, Boolean, RenderType> ARMOR_CUTOUT_NO_CULL_WITH_TRANSPARENCY = Util.memoize((texture, glow) -> armorCutoutWithTransparency(texture, glow, false));

--- a/src/main/java/net/swedz/extended_industrialization/EIClientShaders.java
+++ b/src/main/java/net/swedz/extended_industrialization/EIClientShaders.java
@@ -10,7 +10,7 @@ import net.neoforged.neoforge.client.event.RegisterShadersEvent;
 
 import java.io.IOException;
 
-@EventBusSubscriber(value = Dist.CLIENT, modid = EI.ID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = EI.ID, value = Dist.CLIENT)
 public final class EIClientShaders
 {
 	private static ShaderInstance ARMOR_CUTOUT_GLOW_INSTANCE;

--- a/src/main/java/net/swedz/extended_industrialization/EIMachines.java
+++ b/src/main/java/net/swedz/extended_industrialization/EIMachines.java
@@ -407,6 +407,7 @@ public final class EIMachines
 						.requiresCorrectToolForDrops()
 						.isValidSpawn(MobSpawning.NO_SPAWN)
 						.explosionResistance(3600000))
+				.excludeDefaultBlockProperties()
 				.builtinModel(CableTier.LV.casing, "lethal_tesla_coil", (model) -> model.front(true).top(true).side(true).active(true))
 				.registrator(LethalTeslaCoilMachineBlockEntity::registerEnergyApi)
 				.registerMachine();
@@ -419,6 +420,7 @@ public final class EIMachines
 						.noCollission()
 						.noOcclusion()
 						.instabreak())
+				.excludeDefaultBlockProperties()
 				.excludeDefaultMineableTags()
 				.registerMachine();
 	}

--- a/src/main/java/net/swedz/extended_industrialization/client/ber/tesla/TeslaPartRenderer.java
+++ b/src/main/java/net/swedz/extended_industrialization/client/ber/tesla/TeslaPartRenderer.java
@@ -43,7 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-@EventBusSubscriber(modid = EI.ID, bus = EventBusSubscriber.Bus.GAME, value = Dist.CLIENT)
+@EventBusSubscriber(modid = EI.ID, value = Dist.CLIENT)
 public final class TeslaPartRenderer
 {
 	private static void renderHighlight(MachineBlockEntity machine, float partialTick, PoseStack matrices, MultiBufferSource buffer, int light, int overlay)

--- a/src/main/java/net/swedz/extended_industrialization/commands/EICommands.java
+++ b/src/main/java/net/swedz/extended_industrialization/commands/EICommands.java
@@ -20,7 +20,7 @@ import static net.minecraft.commands.Commands.*;
 import static net.minecraft.commands.arguments.DimensionArgument.*;
 import static net.minecraft.commands.arguments.coordinates.BlockPosArgument.*;
 
-@EventBusSubscriber(modid = EI.ID, bus = EventBusSubscriber.Bus.GAME)
+@EventBusSubscriber(modid = EI.ID)
 public final class EICommands
 {
 	@SubscribeEvent


### PR DESCRIPTION
Uses new method added by Swedz/tesseract-neoforge#156 to override block properties for Lethal Tesla Coil and Tesla Particle Generator.

Also updates Tesseract API to 1.9.2, MI to 2.3.13, and NeoForge to 21.1.209