### PR TITLE
Fix the energy not being consumed by the auto feeder when stored energy is very low

### DIFF
--- a/src/main/java/net/swedz/extended_industrialization/item/RobotAutoFeederItem.java
+++ b/src/main/java/net/swedz/extended_industrialization/item/RobotAutoFeederItem.java
@@ -65,7 +65,7 @@ public final class RobotAutoFeederItem extends Item implements ISimpleEnergyItem
 	
 	public boolean hasEnergy(ItemStack stack)
 	{
-		return this.getStoredEnergy(stack) > 0;
+		return this.getStoredEnergy(stack) >= EAT_ENERGY_COST;
 	}
 	
 	@Override


### PR DESCRIPTION
If the energy stored in an auto feeder is in the range `1-255` the auto feeder will run forever without requiring energy.