### PR TITLE
Fix #290: Limit energy transfer rate of Machine Chainer

### DIFF
--- a/src/main/java/net/swedz/extended_industrialization/EIConfig.java
+++ b/src/main/java/net/swedz/extended_industrialization/EIConfig.java
@@ -23,6 +23,17 @@ public interface EIConfig
 	}
 	
 	@ConfigKey
+	@ConfigComment({
+			"The multiplier applied to the transfer rate of machine chainers. The base transfer rate is equal to the max transfer rate of the cable tier of the chainer (as per the hull).",
+			"Set to 0 for infinite transfer."
+	})
+	@Range.Integer(min = 0, max = 1000)
+	default int machineChainerMaxTransferMultiplier()
+	{
+		return 3;
+	}
+	
+	@ConfigKey
 	@ConfigComment("Whether upgrades should be allowed in the Processing Array")
 	default boolean allowUpgradesInProcessingArray()
 	{

--- a/src/main/java/net/swedz/extended_industrialization/machines/blockentity/MachineChainerMachineBlockEntity.java
+++ b/src/main/java/net/swedz/extended_industrialization/machines/blockentity/MachineChainerMachineBlockEntity.java
@@ -135,6 +135,12 @@ public final class MachineChainerMachineBlockEntity extends MachineBlockEntity i
 		return casing.getCableTier();
 	}
 	
+	public long getMaxTransfer()
+	{
+		int multiplier = EI.config().machineChainerMaxTransferMultiplier();
+		return multiplier == 0 ? Long.MAX_VALUE : this.getCableTier().getMaxTransfer() * multiplier;
+	}
+	
 	@Override
 	public MIInventory getInventory()
 	{
@@ -200,7 +206,7 @@ public final class MachineChainerMachineBlockEntity extends MachineBlockEntity i
 			{
 				transferFluid.autoExtract(level, worldPosition, orientation.outputDirection);
 			}
-			if(transferEnergy.autoExtract(level, worldPosition, orientation.outputDirection, this.getCableTier()))
+			if(transferEnergy.autoExtract(level, worldPosition, orientation.outputDirection, this.getCableTier(), this.getMaxTransfer()))
 			{
 				this.setChanged();
 			}

--- a/src/main/java/net/swedz/extended_industrialization/machines/blockentity/MachineChainerMachineBlockEntity.java
+++ b/src/main/java/net/swedz/extended_industrialization/machines/blockentity/MachineChainerMachineBlockEntity.java
@@ -138,7 +138,7 @@ public final class MachineChainerMachineBlockEntity extends MachineBlockEntity i
 	public long getMaxTransfer()
 	{
 		int multiplier = EI.config().machineChainerMaxTransferMultiplier();
-		return multiplier == 0 ? Long.MAX_VALUE : this.getCableTier().getMaxTransfer() * multiplier;
+		return multiplier == 0 ? Long.MAX_VALUE : (this.getCableTier().getMaxTransfer() * multiplier);
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/extended_industrialization/machines/component/chainer/ChainerComponent.java
+++ b/src/main/java/net/swedz/extended_industrialization/machines/component/chainer/ChainerComponent.java
@@ -40,8 +40,8 @@ public final class ChainerComponent implements MachineComponent, ChainerElement
 		
 		this.itemHandler = new ChainerItemHandler(links);
 		this.fluidHandler = new ChainerFluidHandler(links);
-		this.insertableEnergyHandler = new ChainerEnergyHandler(links, machine::getCableTier, true);
-		this.extractableEnergyHandler = new ChainerEnergyHandler(links, machine::getCableTier, false);
+		this.insertableEnergyHandler = new ChainerEnergyHandler(links, machine::getCableTier, machine::getMaxTransfer, true);
+		this.extractableEnergyHandler = new ChainerEnergyHandler(links, machine::getCableTier, machine::getMaxTransfer, false);
 		
 		this.listenerNeighborNotify = (event) ->
 		{

--- a/src/main/java/net/swedz/extended_industrialization/machines/component/chainer/handler/ChainerEnergyHandler.java
+++ b/src/main/java/net/swedz/extended_industrialization/machines/component/chainer/handler/ChainerEnergyHandler.java
@@ -15,12 +15,14 @@ import java.util.function.Supplier;
 public final class ChainerEnergyHandler extends ChainerHandler<MIEnergyStorage, InventoryWrapper<MIEnergyStorage>> implements MIEnergyStorage
 {
 	private final Supplier<CableTier> cableTier;
+	private final Supplier<Long>      maxTransfer;
 	private final boolean             insertable;
 	
-	public ChainerEnergyHandler(ChainerLinks chainerLinks, Supplier<CableTier> cableTier, boolean insertable)
+	public ChainerEnergyHandler(ChainerLinks chainerLinks, Supplier<CableTier> cableTier, Supplier<Long> maxTransfer, boolean insertable)
 	{
 		super(chainerLinks);
 		this.cableTier = cableTier;
+		this.maxTransfer = maxTransfer;
 		this.insertable = insertable;
 	}
 	
@@ -48,6 +50,7 @@ public final class ChainerEnergyHandler extends ChainerHandler<MIEnergyStorage, 
 		{
 			return 0;
 		}
+		maxReceive = Math.min(maxReceive, maxTransfer.get());
 		return TransferHelper.distributeLong((wrapper, amount, opSimulate) -> wrapper.handler().receive(amount, opSimulate), wrappers, maxReceive, simulate);
 	}
 	
@@ -58,6 +61,7 @@ public final class ChainerEnergyHandler extends ChainerHandler<MIEnergyStorage, 
 		{
 			return 0;
 		}
+		maxExtract = Math.min(maxExtract, maxTransfer.get());
 		return TransferHelper.distributeLong((wrapper, amount, opSimulate) -> wrapper.handler().extract(amount, opSimulate), wrappers, maxExtract, simulate);
 	}
 	


### PR DESCRIPTION
Reduces the max transfer rate of a chainer to 3 times the cable tier's max transfer rate. This multiplier can be configured. Set to 0 for infinite transfer rates (old behavior).