### PR TITLE
Include Curios slots for belt and hands

### DIFF
--- a/src/main/resources/data/extended_industrialization/curios/entities/entities.json
+++ b/src/main/resources/data/extended_industrialization/curios/entities/entities.json
@@ -3,6 +3,8 @@
         "minecraft:player"
     ],
     "slots": [
-        "shoulders"
+        "shoulders",
+        "belt",
+        "hands"
     ]
 }


### PR DESCRIPTION
This lets the Tesla Handheld Receiver be used in Curios slots without the need of another mod adding belt or hand slots.