### PR TITLE
Include option for photovoltaic cells to have a minimum efficiency value

### DIFF
--- a/src/main/java/net/swedz/extended_industrialization/EIItems.java
+++ b/src/main/java/net/swedz/extended_industrialization/EIItems.java
@@ -245,7 +245,7 @@ public final class EIItems
 	
 	public static ItemHolder<PhotovoltaicCellItem> createPhotovoltaicCell(String id, String name, CableTier tier, int euPerTick, int durationTicks)
 	{
-		return create("%s_photovoltaic_cell".formatted(id), "%s Photovoltaic Cell".formatted(name), (p) -> new PhotovoltaicCellItem(p, tier, euPerTick, durationTicks), EISortOrder.PARTS)
+		return create("%s_photovoltaic_cell".formatted(id), "%s Photovoltaic Cell".formatted(name), (p) -> new PhotovoltaicCellItem(p, tier, euPerTick, durationTicks, 0), EISortOrder.PARTS)
 				.tag(EITags.Items.PHOTOVOLTAIC_CELL)
 				.withModelBuilder(CommonModelBuilders::generated)
 				.register();

--- a/src/main/java/net/swedz/extended_industrialization/EITooltips.java
+++ b/src/main/java/net/swedz/extended_industrialization/EITooltips.java
@@ -142,7 +142,7 @@ public final class EITooltips
 				lines.add(EI.text().photovoltaicCellEU(data.euPerTick()));
 				if(!data.lastsForever())
 				{
-					int solarTicksRemaining = data.durationTicks() - stack.getOrDefault(EIComponents.SOLAR_TICKS, 0);
+					int solarTicksRemaining = data.lifetimeTicks() - stack.getOrDefault(EIComponents.SOLAR_TICKS, 0);
 					lines.add(EI.text().photovoltaicCellRemainingOperationTimeMinutes(solarTicksRemaining));
 				}
 				else

--- a/src/main/java/net/swedz/extended_industrialization/component/PhotovoltaicCell.java
+++ b/src/main/java/net/swedz/extended_industrialization/component/PhotovoltaicCell.java
@@ -6,20 +6,23 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import net.swedz.tesseract.api.Assert;
 import net.swedz.tesseract.neoforge.compat.mi.serialization.MICodecs;
 import net.swedz.tesseract.neoforge.compat.mi.serialization.MIStreamCodecs;
 
 public record PhotovoltaicCell(
 		CableTier tier,
 		int euPerTick,
-		int durationTicks
+		int lifetimeTicks,
+		float minimumEfficiency
 )
 {
 	public static final Codec<PhotovoltaicCell> CODEC = RecordCodecBuilder.create((instance) -> instance
 			.group(
 					MICodecs.CABLE_TIER.fieldOf("tier").forGetter(PhotovoltaicCell::tier),
 					Codec.INT.fieldOf("eu_per_tick").forGetter(PhotovoltaicCell::euPerTick),
-					Codec.INT.fieldOf("duration_ticks").forGetter(PhotovoltaicCell::durationTicks)
+					Codec.INT.fieldOf("lifetime_ticks").forGetter(PhotovoltaicCell::lifetimeTicks),
+					Codec.FLOAT.fieldOf("minimum_efficiency").forGetter(PhotovoltaicCell::minimumEfficiency)
 			)
 			.apply(instance, PhotovoltaicCell::new));
 	
@@ -29,12 +32,21 @@ public record PhotovoltaicCell(
 			ByteBufCodecs.INT,
 			PhotovoltaicCell::euPerTick,
 			ByteBufCodecs.INT,
-			PhotovoltaicCell::durationTicks,
+			PhotovoltaicCell::lifetimeTicks,
+			ByteBufCodecs.FLOAT,
+			PhotovoltaicCell::minimumEfficiency,
 			PhotovoltaicCell::new
 	);
 	
+	public PhotovoltaicCell
+	{
+		Assert.that(euPerTick > 0, "EU per tick must be > 0");
+		Assert.that(lifetimeTicks >= 0, "Lifetime ticks must be positive");
+		Assert.that(minimumEfficiency >= 0 && minimumEfficiency <= 1, "Minimum efficiency must be between 0 and 1");
+	}
+	
 	public boolean lastsForever()
 	{
-		return durationTicks == 0;
+		return lifetimeTicks == 0;
 	}
 }

--- a/src/main/java/net/swedz/extended_industrialization/item/PhotovoltaicCellItem.java
+++ b/src/main/java/net/swedz/extended_industrialization/item/PhotovoltaicCellItem.java
@@ -9,12 +9,12 @@ import net.swedz.extended_industrialization.component.PhotovoltaicCell;
 
 public final class PhotovoltaicCellItem extends Item
 {
-	public PhotovoltaicCellItem(Properties properties, CableTier tier, int euPerTick, int durationTicks)
+	public PhotovoltaicCellItem(Properties properties, CableTier tier, int euPerTick, int durationTicks, float minimumEfficiency)
 	{
 		super(properties
 				.stacksTo(1)
 				.durability(0)
-				.component(EIComponents.PHOTOVOLTAIC_CELL, new PhotovoltaicCell(tier, euPerTick, durationTicks))
+				.component(EIComponents.PHOTOVOLTAIC_CELL, new PhotovoltaicCell(tier, euPerTick, durationTicks, minimumEfficiency))
 				.component(EIComponents.SOLAR_TICKS, 0));
 	}
 	
@@ -32,7 +32,7 @@ public final class PhotovoltaicCellItem extends Item
 	{
 		int solarTicks = stack.getOrDefault(EIComponents.SOLAR_TICKS, 0);
 		var cell = stack.get(EIComponents.PHOTOVOLTAIC_CELL);
-		return Math.round(13 - (((float) solarTicks / cell.durationTicks()) * 13));
+		return Math.round(13 - (((float) solarTicks / cell.lifetimeTicks()) * 13));
 	}
 	
 	@Override
@@ -40,8 +40,8 @@ public final class PhotovoltaicCellItem extends Item
 	{
 		int solarTicks = stack.getOrDefault(EIComponents.SOLAR_TICKS, 0);
 		var cell = stack.get(EIComponents.PHOTOVOLTAIC_CELL);
-		int solarTicksRemaining = cell.durationTicks() - solarTicks;
-		float hue = Math.max(0, (float) solarTicksRemaining / cell.durationTicks());
+		int solarTicksRemaining = cell.lifetimeTicks() - solarTicks;
+		float hue = Math.max(0, (float) solarTicksRemaining / cell.lifetimeTicks());
 		return Mth.hsvToRgb(hue / 3, 1, 1);
 	}
 }

--- a/src/main/java/net/swedz/extended_industrialization/machines/blockentity/SolarBoilerMachineBlockEntity.java
+++ b/src/main/java/net/swedz/extended_industrialization/machines/blockentity/SolarBoilerMachineBlockEntity.java
@@ -123,7 +123,10 @@ public final class SolarBoilerMachineBlockEntity extends MachineBlockEntity impl
 	
 	public float getEfficiency(boolean includeCalficiation)
 	{
-		return includeCalficiation ? sunlight.getSolarEfficiency() * calcification.getEfficiency() : sunlight.getSolarEfficiency();
+		float sunlightEfficiency = sunlight.getSolarEfficiency();
+		return includeCalficiation ?
+				sunlightEfficiency * calcification.getEfficiency() :
+				sunlightEfficiency;
 	}
 	
 	@Override

--- a/src/main/java/net/swedz/extended_industrialization/machines/blockentity/SolarPanelMachineBlockEntity.java
+++ b/src/main/java/net/swedz/extended_industrialization/machines/blockentity/SolarPanelMachineBlockEntity.java
@@ -97,7 +97,7 @@ public final class SolarPanelMachineBlockEntity extends MachineBlockEntity imple
 		extractable = energy.buildExtractable((otherTier) -> otherTier == tier);
 		
 		sunlight = new SolarSunlightComponent(this);
-		generator = new SolarGeneratorComponent(inventory, energy, this::getEfficiency, (cell) -> cell.tier() == tier);
+		generator = new SolarGeneratorComponent(inventory, energy, sunlight::getSolarEfficiency, (cell) -> cell.tier() == tier);
 		
 		this.registerGuiComponent(new EnergyBar(new EnergyBar.Params(ENERGY_X, ENERGY_Y), energy::getEu, energy::getCapacity));
 		
@@ -107,16 +107,11 @@ public final class SolarPanelMachineBlockEntity extends MachineBlockEntity imple
 		this.registerGuiComponent(SolarEfficiencyBar.energyProduced(
 				new SolarEfficiencyBar.Params(SOLAR_EFFICIENCY_X, SOLAR_EFFICIENCY_Y),
 				sunlight::canOperate,
-				() -> (int) (this.getEfficiency() * 100),
+				() -> (int) (generator.getEnergyEfficiency() * 100),
 				generator::getEnergyPerTick
 		));
 		
 		this.registerComponents(inventory, energy, redstoneControl, sunlight, generator);
-	}
-	
-	public float getEfficiency()
-	{
-		return sunlight.getSolarEfficiency();
 	}
 	
 	@Override
@@ -175,7 +170,7 @@ public final class SolarPanelMachineBlockEntity extends MachineBlockEntity imple
 			return;
 		}
 		
-		if(sunlight.canOperate() && redstoneControl.doAllowNormalOperation(this))
+		if(generator.getEnergyEfficiency() > 0 && redstoneControl.doAllowNormalOperation(this))
 		{
 			generator.tick();
 		}

--- a/src/main/java/net/swedz/extended_industrialization/machines/component/solar/electric/SolarGeneratorComponent.java
+++ b/src/main/java/net/swedz/extended_industrialization/machines/component/solar/electric/SolarGeneratorComponent.java
@@ -52,9 +52,24 @@ public final class SolarGeneratorComponent implements MachineComponent.ServerOnl
 		return inventory.getItemStacks().getFirst();
 	}
 	
+	private PhotovoltaicCell getPhotovoltaicCellData()
+	{
+		var resource = this.getSlotPhotovoltaicCell().getResource();
+		var components = PatchedDataComponentMap.fromPatch(resource.getItem().components(), resource.getComponentsPatch());
+		return components.get(EIComponents.PHOTOVOLTAIC_CELL.get());
+	}
+	
+	public float getEnergyEfficiency()
+	{
+		float efficiency = energyEfficiency.get();
+		return photovoltaicCell != null ?
+				Math.max(efficiency, photovoltaicCell.minimumEfficiency()) :
+				efficiency;
+	}
+	
 	public long getEnergyPerTick()
 	{
-		return photovoltaicCell != null ? (long) (photovoltaicCell.euPerTick() * energyEfficiency.get() * (usedDistilledWater ? 1.5 : 1)) : 0;
+		return photovoltaicCell != null ? (long) (photovoltaicCell.euPerTick() * this.getEnergyEfficiency() * (usedDistilledWater ? 1.5 : 1)) : 0;
 	}
 	
 	private boolean tryUseDistilledWater()
@@ -70,7 +85,7 @@ public final class SolarGeneratorComponent implements MachineComponent.ServerOnl
 	private void incrementSolarTicks(ItemStack stack)
 	{
 		int solarTicks = stack.getOrDefault(EIComponents.SOLAR_TICKS, 0) + 1;
-		if(solarTicks > photovoltaicCell.durationTicks())
+		if(solarTicks > photovoltaicCell.lifetimeTicks())
 		{
 			return;
 		}
@@ -80,7 +95,7 @@ public final class SolarGeneratorComponent implements MachineComponent.ServerOnl
 	private int getSolarTicksRemaining(ItemStack stack)
 	{
 		int solarTicks = stack.getOrDefault(EIComponents.SOLAR_TICKS, 0);
-		return photovoltaicCell.durationTicks() - solarTicks;
+		return photovoltaicCell.lifetimeTicks() - solarTicks;
 	}
 	
 	private void deterioratePhotovoltaicCell()
@@ -109,9 +124,7 @@ public final class SolarGeneratorComponent implements MachineComponent.ServerOnl
 			tick = 1;
 		}
 		
-		var resource = this.getSlotPhotovoltaicCell().getResource();
-		var components = PatchedDataComponentMap.fromPatch(resource.getItem().components(), resource.getComponentsPatch());
-		var photovoltaicCellComponent = components.get(EIComponents.PHOTOVOLTAIC_CELL.get());
+		var photovoltaicCellComponent = this.getPhotovoltaicCellData();
 		if(photovoltaicCellComponent != null && photovoltaicCellTest.test(photovoltaicCellComponent))
 		{
 			photovoltaicCell = photovoltaicCellComponent;


### PR DESCRIPTION
Not used by default, but something like KubeJS could modify item data components to make cells have a minimum efficiency value